### PR TITLE
Makefile.uk: Use mk_sub_libbuild_dir to create directory hierarchies

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -24,7 +24,7 @@ LIBLUA_SRCS_BASE=$(LIBLUA_ORIGIN)/$(LIBLUA_TARBALL)/src
 ################################################################################
 # Put public headers of the library to a public folder and export them globally.
 # The prepare step below takes care of populating the folder.
-$(call mk_sub_build_dir,liblua/include)
+$(call mk_sub_libbuild_dir,liblua,include)
 CINCLUDES-$(CONFIG_LIBLUA)   += -I$(LIBLUA_BUILD)/include
 CXXINCLUDES-$(CONFIG_LIBLUA) += -I$(LIBLUA_BUILD)/include
 


### PR DESCRIPTION
Unikraft core build system currently enforces the use of `mk_sub_libbuild_dir` function instead of `mk_sub_build_dir` for creating directory hierarchies, i.e. creating more than the first-level subdirectory.

Update `Makefile.uk` accordingly: replace the call to `mk_sub_build_dir` with a call to `mk_sub_libbuild_dir`.